### PR TITLE
Enquote `color` values in sync label config

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -3,28 +3,28 @@
 
 - name: bug
   description: Something isn't working
-  color: d73a4a
+  color: '#d73a4a'
 - name: documentation
   description: Improvements or additions to documentation
-  color: 0075ca
+  color: '#0075ca'
 - name: duplicate
   description: This issue or pull request already exists
-  color: cfd3d7
+  color: '#cfd3d7'
 - name: enhancement
   description: New feature or request
-  color: a2eeef
+  color: '#a2eeef'
 - name: good first issue
   description: Good for newcomers
-  color: 7057ff
+  color: '#7057ff'
 - name: help wanted
   description: Extra attention is needed
-  color: 008672
+  color: '#008672'
 - name: invalid
   description: This doesn't seem right
-  color: e4e669
+  color: '#e4e669'
 - name: question
   description: Further information is requested
-  color: d876e3
+  color: '#d876e3'
 - name: wontfix
   description: This will not be worked on
-  color: ffffff
+  color: '#ffffff'


### PR DESCRIPTION
To prevent it from running into a parsing error on numeric hex values.