### PR TITLE
Add myself to maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,4 +5,5 @@ In alphabetical order:
 - Hidde Beydals, Weaveworks <hidde@hhh.computer> (GitHub: @hiddeco, Slack: hidde)
 - Andrew Block, Red Hat <ablock@redhat.com> (GitHub: @sabre1041, Slack: Andrew Block)
 - Devin Buhl, Individual <devin@buhl.casa> (GitHub: @onedr0p, Slack: Devin Buhl)
+- Felix Fontein, Individual <felix@fontein.de> (GitHub: @felixfontein, Matrix: felixfontein:matrix.org, Libera.Chat IRC: felixfontein)
 - Devin Stein, Individual <devstein@alumni.upenn.edu> (GitHub: @devstein)


### PR DESCRIPTION
@hiddeco approached me whether I want to join the group of SOPS maintainers, and here I am :)

I wasn't sure whether only relevant communication channels should be listed (i.e. email/GH/Slack) or also others, so I added Matrix and IRC. I can remove them if you want to keep the list shorter :)
